### PR TITLE
Add timeout option

### DIFF
--- a/src/derange.ts
+++ b/src/derange.ts
@@ -33,12 +33,28 @@ export const validateMatches: ValidateMatches = (
   });
 };
 
-export const derange = (
+export function derange(people: Person[], exclusions?: Exclusion[]): Person[];
+export function derange(
   people: Person[],
-  exclusions: Exclusion[] = []
-): Person[] => {
+  options?: { exclusions?: Exclusion[]; timeout?: number }
+): Person[];
+
+export function derange(
+  people: Person[],
+  exclusionsOrOptions?:
+    | { exclusions?: Exclusion[]; timeout?: number }
+    | Exclusion[]
+): Person[] {
   if (people.length < 2) {
     return people.slice(0);
+  }
+  let exclusions: Exclusion[];
+  let timeout = 1000;
+  if (Array.isArray(exclusionsOrOptions)) {
+    exclusions = exclusionsOrOptions;
+  } else {
+    exclusions = exclusionsOrOptions?.exclusions ?? [];
+    timeout = exclusionsOrOptions?.timeout ?? 1000;
   }
 
   let buffer1: Person[] = [];
@@ -57,7 +73,7 @@ export const derange = (
   const startTime = Date.now();
   const testDerangement: ValidateMatches = (...args): boolean => {
     // prevent infinite loops when no combination is found
-    if (Date.now() - startTime > 1e3)
+    if (Date.now() - startTime > timeout)
       throw new DerangementError('No derangement found');
     return validateMatches(...args);
   };
@@ -72,17 +88,27 @@ export const derange = (
     const personIndex = buffer1.findIndex(match => match.name === p.name);
     return buffer2[personIndex];
   });
-};
+}
 
-export const calculate = (
+export function calculate(people: Person[], exclusions?: Exclusion[]): Promise<Person[]>;
+export function calculate(
   people: Person[],
-  exclusions: Exclusion[] = []
-): Promise<Person[]> => {
+  options?: { exclusions?: Exclusion[]; timeout?: number }
+): Promise<Person[]>;
+/**
+ * @deprecated
+ * This is thread blocking, even when in wrapped in a Promise
+ * A better non-blocking approach would be to wrap the call in a WebWorker
+ */
+export function calculate(
+  people: Person[],
+  exclusionsOrOptions?: any
+): Promise<Person[]> {
   return new Promise((resolve, reject) => {
     try {
-      resolve(derange(people, exclusions));
+      resolve(derange(people, exclusionsOrOptions));
     } catch (e) {
       reject(e);
     }
   });
-};
+}

--- a/test/derange.test.ts
+++ b/test/derange.test.ts
@@ -349,6 +349,33 @@ describe('derange', () => {
       expect(() => derange(input, exclusions)).not.toBeValidDerangement(input);
     });
 
+    it('throws an error when an impossible combination is received with a custom timeout', () => {
+      const input = personArrayOfLength(3);
+      const exclusions: Exclusion[] = [
+        {
+          type: 'name',
+          subject: '2',
+          excludedType: 'name',
+          excludedSubject: '1'
+        },
+        {
+          type: 'name',
+          subject: '1',
+          excludedType: 'name',
+          excludedSubject: '2'
+        }
+      ];
+
+      const start = Date.now();
+
+      expect(() => derange(input, { exclusions, timeout: 10 })).toThrowError();
+      expect(() =>
+        derange(input, { exclusions, timeout: 10 })
+      ).not.toBeValidDerangement(input);
+
+      expect(Date.now() - start).toBeGreaterThanOrEqual(20);
+    });
+
     it('deranges with a name exclusion', () => {
       const input = personArrayOfLength(3);
       const exclusions: Exclusion[] = [
@@ -361,6 +388,20 @@ describe('derange', () => {
       ];
 
       expect(derange(input, exclusions)).toBeValidDerangement(input);
+    });
+
+    it('deranges with a name exclusion using object argument syntax', () => {
+      const input = personArrayOfLength(3);
+      const exclusions: Exclusion[] = [
+        {
+          type: 'name',
+          subject: '2',
+          excludedType: 'name',
+          excludedSubject: '1'
+        }
+      ];
+
+      expect(derange(input, { exclusions })).toBeValidDerangement(input);
     });
 
     it('deranges with a group exclusion', () => {


### PR DESCRIPTION
- Add timeout option, still defaults to 1000ms
- Add new options Object syntax for passing in exclusions and timeouts
- Deprecate the calculate function

If an impossible, or slow match is under way, the thread will be blocked until the timeout, or a match is found. Wrapping this in a Promise doesn't change this, so it's an unhelpful function.